### PR TITLE
Add a GitHub action for release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,32 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: Build workflow
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+          check-latest: true
+          cache: true
+      - name: Build binaries
+        run: |
+          GOOS=darwin GOARCH=arm64 go build -o dictcc_arm64 main.go
+          GOOS=darwin GOARCH=amd64 go build -o dictcc_amd64 main.go
+      - name: Bundle workflow
+        run: |
+          mkdir dist
+          zip dist/Dict.cc.alfredworkflow dictcc_arm64 dictcc_amd64 assets/info.plist assets/icon.png
+      - name: Create or update the GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/Dict.cc.alfredworkflow


### PR DESCRIPTION
This adds a GitHub action to build and release the workflow whenever a tag is pushed that looks like a semver tag.

When a release with a corresponding tag is created through the GitHub interface, this action runs. It builds and packages the workflow and then adds the workflow to the existing GitHub release.

If a tag is pushed, but no GitHub release exists, it creates a new one. The title is going to be the pushed tag and the body the commit message of the commit the tag points to.

Relates to: #12